### PR TITLE
Fix product picker variants

### DIFF
--- a/src/Ucommerce.Masterclass.Umbraco/Views/Product/Index.cshtml
+++ b/src/Ucommerce.Masterclass.Umbraco/Views/Product/Index.cshtml
@@ -1,4 +1,5 @@
-﻿@using Ucommerce
+﻿@using System.Diagnostics.Eventing.Reader
+@using Ucommerce
 @using Ucommerce.Catalog.Models
 @model Ucommerce.Masterclass.Umbraco.Models.ProductViewModel
 @{
@@ -42,7 +43,7 @@
                             <h1 class="text-success">@formattedPrice</h1>
                         }
                     </div>
-                    @if (Model.Variants.Any())
+                    @if (!Model.Sellable && Model.Variants.Any())
                     {
                         <div class="col-md-7 p-4">
                             <div class="col-md-12">
@@ -59,10 +60,19 @@
                     }
                 </div>
                 <div class="row">
-                    <div class="col-md-12 p-4">
-                        <input type="number" name="quantity" class="col-md-12" min="1" value="1"/>
-                        <button class="btn btn-primary col-md-12 mt-2" form="@Model.Sku" type="submit"><i class="fa fa-shopping-cart"></i> Add to cart</button>
-                    </div>
+                    @if (Model.Sellable || Model.Variants.Any()) 
+                    {
+                        <div class="col-md-12 p-4">
+                            <input type="number" name="quantity" class="col-md-12" min="1" value="1"/>
+                            <button class="btn btn-primary col-md-12 mt-2" form="@Model.Sku" type="submit"><i class="fa fa-shopping-cart"></i> Add to cart</button>
+                        </div>
+                    }
+                    @if (!Model.Sellable && !Model.Variants.Any())
+                    {
+                        <div class="col-md-12 p-4">
+                            <legend>It appears that this product is out.</legend>
+                        </div>
+                    }
                 </div>
             </div>
         </form>

--- a/src/Ucommerce.Masterclass.Umbraco/Views/Product/Index.cshtml
+++ b/src/Ucommerce.Masterclass.Umbraco/Views/Product/Index.cshtml
@@ -1,5 +1,4 @@
-﻿@using System.Diagnostics.Eventing.Reader
-@using Ucommerce
+﻿@using Ucommerce
 @using Ucommerce.Catalog.Models
 @model Ucommerce.Masterclass.Umbraco.Models.ProductViewModel
 @{


### PR DESCRIPTION
The picker was not working properly. It only looked for variants, so if you had a family with no variants it would show the add to cart button.